### PR TITLE
Allow building dynamic targets

### DIFF
--- a/src/main/kotlin/me/serce/bazillion/libs.kt
+++ b/src/main/kotlin/me/serce/bazillion/libs.kt
@@ -186,7 +186,7 @@ class LibManager(private val project: Project) : PersistentStateComponent<LibMan
     return actualLibraries.getOrPut(name) {
       val process = process(
         projectRoot, bazelPath, "cquery", name,
-        "--output=starlark", "--starlark:expr", "'\\n'.join([l.path for l in target.files.to_list()])"
+        "--output=starlark", "--starlark:expr", "'\\n'.join([f.path for f in target.files.to_list()])"
       )
       if (!(process.waitFor(60, TimeUnit.SECONDS) && process.exitValue() == 0)) {
         LOG.error("Couldn't get $name bazel target's output path")

--- a/src/main/kotlin/me/serce/bazillion/libs.kt
+++ b/src/main/kotlin/me/serce/bazillion/libs.kt
@@ -69,7 +69,7 @@ class LibManager(private val project: Project) : PersistentStateComponent<LibMan
   fun getLibMeta(path: String) = librariesMeta[path]
   fun getAllLibs(): Collection<LibraryData> = actualLibraries.values
 
-  val projectRoot = File(project.basePath)
+  private val projectRoot = File(project.basePath)
 
   fun refresh(progress: ProgressIndicator) {
     actualLibraries.clear()

--- a/src/main/kotlin/me/serce/bazillion/libs.kt
+++ b/src/main/kotlin/me/serce/bazillion/libs.kt
@@ -184,8 +184,10 @@ class LibManager(private val project: Project) : PersistentStateComponent<LibMan
 
   fun getBazelLib(name: String): LibraryData? {
     return actualLibraries.getOrPut(name) {
-      val process = process(projectRoot, bazelPath, "cquery", name,
-        "--output=starlark", "--starlark:expr", "'\\n'.join([l.path for l in target.files.to_list()])")
+      val process = process(
+        projectRoot, bazelPath, "cquery", name,
+        "--output=starlark", "--starlark:expr", "'\\n'.join([l.path for l in target.files.to_list()])"
+      )
       if (!(process.waitFor(60, TimeUnit.SECONDS) && process.exitValue() == 0)) {
         LOG.error("Couldn't get $name bazel target's output path")
         return null

--- a/src/main/kotlin/me/serce/bazillion/libs.kt
+++ b/src/main/kotlin/me/serce/bazillion/libs.kt
@@ -176,7 +176,7 @@ class LibManager(private val project: Project) : PersistentStateComponent<LibMan
   }
 
   private val executionRoot by lazy {
-    val process = process(projectRoot, "bazel", "info", "execution_root")
+    val process = process(projectRoot, bazelPath, "info", "execution_root")
     process.inputStream.bufferedReader().readLine()
   }
 
@@ -184,7 +184,7 @@ class LibManager(private val project: Project) : PersistentStateComponent<LibMan
 
   fun getBazelLib(name: String): LibraryData? {
     return actualLibraries.getOrPut(name) {
-      val process = process(projectRoot, "cquery", name,
+      val process = process(projectRoot, bazelPath, "cquery", name,
         "--output=starlark", "--starlark:expr", "'\\n'.join([l.path for l in target.files.to_list()])")
       if (!(process.waitFor(60, TimeUnit.SECONDS) && process.exitValue() == 0)) {
         LOG.error("Couldn't get $name bazel target's output path")
@@ -201,7 +201,7 @@ class LibManager(private val project: Project) : PersistentStateComponent<LibMan
   }
 
   fun buildBazelLibs() {
-    process(projectRoot, "bazel", "build", *bazelLibs.toTypedArray())
+    process(projectRoot, bazelPath, "build", *bazelLibs.toTypedArray())
   }
 
   fun getJarLibs(buildFileFolderPath: String, jars: List<String>): List<LibraryData> {

--- a/src/main/kotlin/me/serce/bazillion/process.kt
+++ b/src/main/kotlin/me/serce/bazillion/process.kt
@@ -19,6 +19,11 @@ private val environment = run {
   }
 }
 
+val bazelPath: String by lazy {
+  val process = process(File("/"), "which", "bazel")
+  process.inputStream.bufferedReader().readLine()
+}
+
 fun process(directory: File, vararg command: String): Process {
   val processBuilder = ProcessBuilder(*command).directory(directory)
   for ((key, value) in environment) {

--- a/src/main/kotlin/me/serce/bazillion/process.kt
+++ b/src/main/kotlin/me/serce/bazillion/process.kt
@@ -1,0 +1,28 @@
+package me.serce.bazillion
+
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+private val environment = run {
+  val processBuilder = ProcessBuilder("/bin/bash", "-c", ". \${HOME}/.nix-profile/etc/profile.d/nix.sh && printenv")
+  processBuilder.environment()["PATH"] = run {
+    val current = processBuilder.environment()["PATH"]?.split(':').orEmpty()
+    val needed = listOf("/usr/bin", "/usr/local/bin")
+    (needed + current).distinct().joinToString(":") { it }
+  }
+
+  val process = processBuilder.start()
+  process.waitFor(60, TimeUnit.SECONDS)
+  process.inputStream.bufferedReader().readLines().map {
+    val (key, value) = it.split('=')
+    key to value
+  }
+}
+
+fun process(directory: File, vararg command: String): Process {
+  val processBuilder = ProcessBuilder(*command).directory(directory)
+  for ((key, value) in environment) {
+    processBuilder.environment()[key] = value
+  }
+  return processBuilder.start()
+}

--- a/src/main/kotlin/me/serce/bazillion/project.kt
+++ b/src/main/kotlin/me/serce/bazillion/project.kt
@@ -464,7 +464,7 @@ class RuleManager(
       val exports: List<String>,
       val deps: List<String>,
       val jars: List<String>,
-      val runtimeDeps: List<String>,
+      val runtimeDeps: List<String>
     )
 
     data class Alias(
@@ -578,7 +578,7 @@ class RuleManager(
               exports = fields["exports"] ?: emptyList(),
               deps = fields["deps"] ?: emptyList(),
               jars = jars,
-              runtimeDeps = fields["runtimeDeps"] ?: emptyList(),
+              runtimeDeps = fields["runtimeDeps"] ?: emptyList()
             )
           } else {
             println("Failed to process $funCall")
@@ -653,7 +653,6 @@ class RuleManager(
               if (depPrefixEnd <= 0) {
                 val bazelLib = libManager.getBazelLib(dep)
                 bazelLib?.let { deps.add(it) }
-//                LOG.warn("Can't find dependency '$dep' in the list of libraries")
               } else {
                 val depName = dep.substring(depPrefixEnd + "//:".length)
                 libManager.getActualLib(depName)?.let { library ->

--- a/src/main/kotlin/me/serce/bazillion/project.kt
+++ b/src/main/kotlin/me/serce/bazillion/project.kt
@@ -415,7 +415,6 @@ enum class RuleKind(vararg val names: String) {
   DATANUCLEUS_JAVA_LIBRARY("datanucleus_java_library"),
   JUNIT_TESTS("java_test", "junit_tests"),
   GEN_RULE("genrule"),
-//  ALIAS("alias"),
   DUMMY("dummy$"),
   COMPILE_SOY("compile_soy");
 
@@ -466,7 +465,6 @@ class RuleManager(
       val deps: List<String>,
       val jars: List<String>,
       val runtimeDeps: List<String>,
-//      val aliasedRule: String? = null,
     )
 
     val aliases = mutableListOf<Alias>()
@@ -522,7 +520,6 @@ class RuleManager(
           var name: String? = null
           val fields = mutableMapOf<String, MutableList<String>>()
           val jars = mutableListOf<String>()
-//          var aliasedRule: String? = null
 
           for (argument in funCall) {
             val argName = argument.name
@@ -538,8 +535,6 @@ class RuleManager(
                   )
                 }
               }
-//            } else if (argName == "actual") {
-//              aliasedRule = (argument.value as? StringLiteral)?.value
             } else if (argName != null && argName in listOf("exports", "deps", "runtimeDeps")) {
               fun collectLibs(libList: Expression?, fields: MutableMap<String, MutableList<String>>, argName: String) {
                 when (libList) {
@@ -578,7 +573,6 @@ class RuleManager(
               deps = fields["deps"] ?: emptyList(),
               jars = jars,
               runtimeDeps = fields["runtimeDeps"] ?: emptyList(),
-//              aliasedRule = aliasedRule,
             )
           } else {
             println("Failed to process $funCall")

--- a/src/main/kotlin/me/serce/bazillion/project.kt
+++ b/src/main/kotlin/me/serce/bazillion/project.kt
@@ -687,6 +687,7 @@ class RuleManager(
           }
         }
       }
+
       val jars = mutableListOf<LibraryData>()
       if (rawRule.kind != RuleKind.JAVA_PROTO_LIBRARY) {
         fillDeps(deps, rawRule.deps + rawRule.exports, { it.deps + it.exports })

--- a/src/main/kotlin/me/serce/bazillion/project.kt
+++ b/src/main/kotlin/me/serce/bazillion/project.kt
@@ -713,6 +713,7 @@ class RuleManager(
           .put(name, rule)
       }
     }
+    libManager.buildBazelLibs()
     rules = result
   }
 

--- a/src/main/kotlin/me/serce/bazillion/project.kt
+++ b/src/main/kotlin/me/serce/bazillion/project.kt
@@ -437,12 +437,6 @@ data class Rule(
   val runtimeDeps: Set<AbstractNamedData>
 )
 
-data class Alias(
-  val path: String,
-  val alias: String,
-  val reference: String,
-)
-
 fun isNonProjectDirectory(it: File) = it.isDirectory && (
   it.name.startsWith(".") ||
     it.name.startsWith("bazel-") ||
@@ -473,6 +467,12 @@ class RuleManager(
       val runtimeDeps: List<String>,
     )
 
+    data class Alias(
+      val path: String,
+      val alias: String,
+      val actual: String,
+    )
+
     val aliases = mutableListOf<Alias>()
 
     LOG.info("searching for BUILDs")
@@ -501,15 +501,15 @@ class RuleManager(
             .map { funCall -> funCall.arguments.filterIsInstance<Argument.Keyword>() }
             .mapNotNull { arguments ->
               var alias: String? = null
-              var reference: String? = null
+              var actual: String? = null
               for (arg in arguments) {
                 val value = (arg.value as? StringLiteral)?.value
                 when (arg.name) {
                   "name" -> alias = value
-                  "actual" -> reference = value
+                  "actual" -> actual = value
                 }
               }
-              if (alias != null && reference != null) Alias(projectName, alias, reference) else null
+              if (alias != null && actual != null) Alias(projectName, alias, actual) else null
             }
         )
 


### PR DESCRIPTION
This includes the following changes:
- Support the `alias()` function
- Support the `java_proto_library()` function
- Build the following with Bazel:
  - Targets under `java_proto_library()`
  - External targets included in Bazel, e.g. `@stringtemplate4//jar`, `@antlr3_runtime//jar`
- Require JDK 17

This aims to fix importing a project that has dynamic dependencies.

Dynamic builds in more detail:
- Targets that start with `@` but are not in the form of `@maven//:<target>` are considered external
- Targets under `java_proto_library()` function are considered dynamic
- The output of dynamic these targets are fetched using the `cquery` Bazel command
- The targets are collected and built at the end of the import
- The build is performed using native processes stated from the JDK, using `bazel` installed on the host machine. To ensure that the commands are available, the environment is extended