### PR TITLE
Add JMH core dep to benchmarks

### DIFF
--- a/src/main/kotlin/me/serce/bazillion/project.kt
+++ b/src/main/kotlin/me/serce/bazillion/project.kt
@@ -593,6 +593,18 @@ class RuleManager(
           libManager.getLibMeta(library.externalName)?.let { deps.addAll(it.allDependencies) }
         }
       }
+      // add jmh to all benchmarks
+      if (rawRule.kind == RuleKind.JMH_BENCHMARKS) {
+        listOf(
+          "@maven//:org_openjdk_jmh_jmh_core"
+        ).mapNotNull {
+          val depName = it.substring("@maven//:".length)
+          libManager.getActualLib(depName)
+            ?: run { LOG.warn("Can't find dependency '$it' in the list of libraries"); null }
+        }.forEach { library ->
+          libManager.getLibMeta(library.externalName)?.let { deps.addAll(it.allDependencies) }
+        }
+      }
 
       fun fillDeps(
         deps: MutableSet<AbstractNamedData>,


### PR DESCRIPTION
This could, unfortunately, be a little brittle, but it's in keeping with how we ensure junit exists for all unit tests and means we don't need to find and parse `.bzl` files